### PR TITLE
always generate a jwt token

### DIFF
--- a/slurm_ops_manager/slurm_ops_base.py
+++ b/slurm_ops_manager/slurm_ops_base.py
@@ -482,10 +482,6 @@ class SlurmOpsManagerBase:
 
     def write_slurm_config(self, context) -> None:
         """Render the context to a template, adding in common configs."""
-        if operating_system() == 'ubuntu':
-            enable_jwt = True
-        else:
-            enable_jwt = False
 
         common_config = {
             'munge_socket': str(self._munge_socket),
@@ -499,7 +495,6 @@ class SlurmOpsManagerBase:
             'slurmdbd_pid_file': str(self._slurmdbd_pid_file),
             'slurmd_pid_file': str(self._slurmd_pid_file),
             'slurmctld_pid_file': str(self._slurmctld_pid_file),
-            'enable_jwt': enable_jwt,
             'jwt_rsa_key_file': str(self._jwt_rsa_key_file),
             'slurmctld_parameters': ",".join(self._slurmctld_parameters),
             'slurm_plugstack_conf': str(self._slurm_plugstack_conf),

--- a/slurm_ops_manager/templates/slurm.conf.tmpl
+++ b/slurm_ops_manager/templates/slurm.conf.tmpl
@@ -18,10 +18,8 @@ SlurmctldParameters={{ slurmctld_parameters }}
 
 AuthType=auth/munge
 AuthInfo="socket={{ munge_socket }}"
-{% if enable_jwt %}
 AuthAltTypes=auth/jwt
 AuthAltParameters="jwt_key={{ jwt_rsa_key_file }}"
-{% endif %}
 
 
 CryptoType=crypto/munge

--- a/slurm_ops_manager/templates/slurmdbd.conf.tmpl
+++ b/slurm_ops_manager/templates/slurmdbd.conf.tmpl
@@ -12,10 +12,8 @@ DbdPort={{ active_slurmdbd_port }}
 
 AuthType=auth/munge
 AuthInfo=socket={{ munge_socket }}
-{% if enable_jwt %}
 AuthAltTypes=auth/jwt
 AuthAltParameters="jwt_key={{ jwt_rsa_key_file }}"
-{% endif %}
 
 SlurmUser={{ slurm_user }}
 

--- a/slurm_ops_manager/templates/slurmrestd.service
+++ b/slurm_ops_manager/templates/slurmrestd.service
@@ -11,7 +11,7 @@ EnvironmentFile=-/etc/default/slurmrestd
 # Default to local auth via socket
 #ExecStart=/usr/sbin/slurmrestd $SLURMRESTD_OPTIONS unix:/run/slurmrestd.socket
 # Uncomment to enable listening mode
-#Environment="SLURM_JWT=daemon"
+Environment="SLURM_JWT=daemon"
 ExecStart=/usr/sbin/slurmrestd $SLURMRESTD_OPTIONS -vv 0.0.0.0:6820
 ExecReload=/bin/kill -HUP $MAINPID
 


### PR DESCRIPTION
Centos provides slurmrestd on EPEL7, no need to worry about that anymore
:)