### PR TITLE
Stop all daemons

### DIFF
--- a/slurm_ops_manager/slurm_ops.py
+++ b/slurm_ops_manager/slurm_ops.py
@@ -201,7 +201,7 @@ class SlurmManager(Object):
 
     def slurm_cmd(self, command, arg_string):
         """Run a slurm command."""
-        self._slurm_resource_manager.slurm_cmd(command, arg_string)
+        return self._slurm_resource_manager.slurm_cmd(command, arg_string)
 
     def generate_jwt_rsa(self) -> str:
         """Generate the jwt rsa key."""

--- a/slurm_ops_manager/slurm_ops.py
+++ b/slurm_ops_manager/slurm_ops.py
@@ -162,9 +162,9 @@ class SlurmManager(Object):
         self._slurm_resource_manager.create_configless_systemd_override(host,
                                                                         port)
 
-    def slurm_systemctl(self, cmd):
+    def slurm_systemctl(self, cmd) -> bool:
         """Proxy for slurm_systemctl."""
-        self._slurm_resource_manager.slurm_systemctl(cmd)
+        return self._slurm_resource_manager.slurm_systemctl(cmd)
 
     def slurm_is_active(self) -> bool:
         """Proxy for slurm_is_active."""
@@ -176,7 +176,7 @@ class SlurmManager(Object):
 
     def restart_slurm_component(self):
         """Restart slurm component."""
-        self._slurm_resource_manager.restart_slurm_component()
+        return self._slurm_resource_manager.restart_slurm_component()
 
     def restart_munged(self) -> bool:
         """Restart munged.

--- a/slurm_ops_manager/slurm_ops.py
+++ b/slurm_ops_manager/slurm_ops.py
@@ -97,6 +97,12 @@ class SlurmManager(Object):
 
         self._slurm_resource_manager.create_systemd_override_for_nofile()
         self._slurm_resource_manager.daemon_reload()
+
+        # At this point, munged and slurmxxxd are enabled, we stop them to have
+        # a consistent startup sequence in the charms
+        self._slurm_resource_manager.slurm_systemctl("stop")
+        self._slurm_resource_manager.stop_munged()
+
         self._stored.slurm_installed = True
 
         return True

--- a/slurm_ops_manager/slurm_ops.py
+++ b/slurm_ops_manager/slurm_ops.py
@@ -185,9 +185,19 @@ class SlurmManager(Object):
         """
         return self._slurm_resource_manager.handle_restart_munged()
 
-    def start_munged(self):
-        """Start munged."""
-        self._slurm_resource_manager.start_munged()
+    def start_munged(self) -> bool:
+        """Start munged.
+
+        Returns True if munge starts successfully, and False otherwise.
+        """
+        return self._slurm_resource_manager.start_munged()
+
+    def check_munged(self) -> bool:
+        """Check wether munge is working correctly.
+
+        Returns True if munge is running, and False otherwise.
+        """
+        return self._slurm_resource_manager.check_munged()
 
     def slurm_cmd(self, command, arg_string):
         """Run a slurm command."""

--- a/slurm_ops_manager/slurm_ops_base.py
+++ b/slurm_ops_manager/slurm_ops_base.py
@@ -588,8 +588,8 @@ class SlurmOpsManagerBase:
         return b64encode(munge_key).decode()
 
     def start_munged(self):
-        """Enable and start munge.service."""
-        logger.debug("## Enabling and starting munge")
+        """Start munge.service."""
+        logger.debug("## Starting munge")
 
         munge = self._munged_systemd_service
         subprocess.call(["systemctl", "start", munge])
@@ -606,6 +606,11 @@ class SlurmOpsManagerBase:
         except subprocess.CalledProcessError as e:
             logger.error(f"## Error starting munged - {e}")
             return -1
+
+    def stop_munged(self):
+        """Stop munge.service."""
+        logger.debug("## Stoping munge")
+        subprocess.call(["systemctl", "stop", self._munged_systemd_service])
 
     def handle_restart_munged(self) -> bool:
         """Restart the munged process.

--- a/slurm_ops_manager/slurm_ops_base.py
+++ b/slurm_ops_manager/slurm_ops_base.py
@@ -120,8 +120,8 @@ class SlurmOpsManagerBase:
         logger.debug("## issuing systemctl daemon-reload")
         subprocess.call(["systemctl", "daemon-reload"])
 
-    def slurm_systemctl(self, operation):
-        """Start systemd services for slurmd."""
+    def slurm_systemctl(self, operation) -> bool:
+        """Run systemd commands for Slurm service units."""
         logger.debug(f"## Running slurm_systemctl {operation}")
         supported_systemctl_cmds = [
             "enable",
@@ -135,13 +135,15 @@ class SlurmOpsManagerBase:
             logger.error(msg)
             raise Exception(msg)
         try:
-            subprocess.call([
+            subprocess.check_output([
                 "systemctl",
                 operation,
                 self._slurm_systemd_service,
             ])
+            return True
         except subprocess.CalledProcessError as e:
             logger.error(f"## Error running {operation}: {e}")
+            return False
 
     @property
     def _slurm_bin_dir(self) -> Path:
@@ -550,9 +552,9 @@ class SlurmOpsManagerBase:
         user_group = f"{self._slurm_user}:{self._slurm_group}"
         subprocess.call(["chown", user_group, target])
 
-    def restart_slurm_component(self):
+    def restart_slurm_component(self) -> bool:
         """Restart the slurm component."""
-        self.slurm_systemctl("restart")
+        return self.slurm_systemctl("restart")
 
     def write_munge_key(self, munge_key):
         """Base64 decode and write the munge key."""


### PR DESCRIPTION
This PR makes all daemons stop after installation. This is to have a consistent startup in the charm code.

There are also some minor changes, like forwarding the return code of internal functions, improving docstrings, and type hints.