### PR TITLE
add methods to configure Fluentbit

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ exclude =
     __pycache__,
     .tox,
     mod,
-ignore = D202, E261, W503
+ignore = D202, E241, E261, W503
 max-line-length = 99
 max-complexity = 10
 import-order-style = edited


### PR DESCRIPTION
Generate the configuration parameters to forward NHC and Slurm logs
using Fluentbit charm.