### PR TITLE
Add operating_system attribute in the SlurmManager class

### DIFF
--- a/slurm_ops_manager/slurm_ops.py
+++ b/slurm_ops_manager/slurm_ops.py
@@ -34,11 +34,9 @@ class SlurmManager(Object):
         self._stored.set_default(slurm_installed=False)
         self._stored.set_default(slurm_version_set=False)
 
-        operating_system = utils.operating_system()
-
-        if operating_system == "ubuntu":
+        if self.operating_system == "ubuntu":
             self._slurm_resource_manager = SlurmDebManager(component)
-        elif operating_system == "centos":
+        elif self.operating_system == "centos":
             self._slurm_resource_manager = SlurmRpmManager(component)
         else:
             raise Exception("Unsupported OS")
@@ -51,6 +49,11 @@ class SlurmManager(Object):
     def hostname(self):
         """Return the hostname."""
         return self._slurm_resource_manager.hostname
+
+    @property
+    def operating_system(self):
+        """Return the operating system."""
+        return utils.operating_system()
 
     @property
     def port(self):


### PR DESCRIPTION
This new feature adds the operating_system attribute in the SlurmManager class.

This is necessary for https://github.com/jaimesouza/slurm-charms/tree/jaime-dev-singularity

**How was the code tested?**

The code was tested with a simple example execution. Therefore, it needs a proper test.


Final checklist
- [ x ] I am the author of these changes, or I have the rights to submit them.
- [ ] I added the relevant changed to the README and/or documentation.
- [ x ] I self reviewed my own code.
- [ ] I updated the `CHANGELOG` according to the [contributing
  guide](https://omnivector-solutions.github.io/osd-documentation/master/contributing.html#changelog)