### PR TITLE
Add support for singularity installation

### DIFF
--- a/slurm_ops_manager/singularity.py
+++ b/slurm_ops_manager/singularity.py
@@ -21,8 +21,7 @@ class Singularity(Object):
         """Initialize class."""
         super().__init__(parent, key)
 
-        self._stored.set_default(singularity_installed=False,
-                                 resource_name=str())
+        self._stored.set_default(resource_name=str())
 
         self._operating_system = operating_system()
 
@@ -36,11 +35,6 @@ class Singularity(Object):
             self._stored.resource_name = ""
 
     @property
-    def installed(self) -> bool:
-        """Return wether singularity is installed."""
-        return self._stored.singularity_installed
-
-    @property
     def resource_name(self) -> str:
         """Return singularity resource name."""
         return self._stored.resource_name
@@ -50,8 +44,8 @@ class Singularity(Object):
 
         logger.debug(f"#### Installing singularity from: {resource_path}")
 
-        cmds = {"ubuntu": f"apt install {resource_path} -y",
-                "centos": f"yum localinstall {resource_path} -y"}
+        cmds = {"ubuntu": f"apt-get install --yes {resource_path}",
+                "centos": f"yum localinstall --assumeyes {resource_path}"}
 
         os_ = self._operating_system
         logger.debug(f"#### Installing on {self._operating_system}")
@@ -60,5 +54,3 @@ class Singularity(Object):
         subprocess.run(shlex.split(cmds[os_]))
 
         logger.debug("#### Singularity successfully installed")
-
-        self._stored.singularity_installed = True

--- a/slurm_ops_manager/singularity.py
+++ b/slurm_ops_manager/singularity.py
@@ -1,0 +1,64 @@
+"""Singularity Class."""
+
+import logging
+import shlex
+import subprocess
+from pathlib import Path
+
+from ops.framework import Object, StoredState
+from slurm_ops_manager.utils import operating_system
+
+
+logger = logging.getLogger()
+
+
+class Singularity(Object):
+    """Responsible for Singularity operations."""
+
+    _stored = StoredState()
+
+    def __init__(self, parent, key):
+        """Initialize class."""
+        super().__init__(parent, key)
+
+        self._stored.set_default(singularity_installed=False,
+                                 resource_name=str())
+
+        self._operating_system = operating_system()
+
+        # setup resource name based on operating system
+        if self._operating_system == "ubuntu":
+            self._stored.resource_name = "singularity-deb"
+        elif self._operating_system == "centos":
+            self._stored.resource_name = "singularity-rpm"
+        else:
+            logger.error(f"#### Unsupported OS: {self._operating_system}")
+            self._stored.resource_name = ""
+
+    @property
+    def installed(self) -> bool:
+        """Return wether singularity is installed."""
+        return self._stored.singularity_installed
+
+    @property
+    def resource_name(self) -> str:
+        """Return singularity resource name."""
+        return self._stored.resource_name
+
+    def install(self, resource_path: Path):
+        """Install Singularity."""
+
+        logger.debug(f"#### Installing singularity from: {resource_path}")
+
+        cmds = {"ubuntu": f"apt install {resource_path} -y",
+                "centos": f"yum localinstall {resource_path} -y"}
+
+        os_ = self._operating_system
+        logger.debug(f"#### Installing on {self._operating_system}")
+        logger.debug(f"#### Command: {cmds[os_]}")
+
+        subprocess.run(shlex.split(cmds[os_]))
+
+        logger.debug("#### Singularity successfully installed")
+
+        self._stored.singularity_installed = True

--- a/slurm_ops_manager/slurm_ops.py
+++ b/slurm_ops_manager/slurm_ops.py
@@ -10,6 +10,7 @@ from ops.framework import (
 from slurm_ops_manager import utils
 from slurm_ops_manager.infiniband import Infiniband
 from slurm_ops_manager.nvidia import NvidiaGPU
+from slurm_ops_manager.singularity import Singularity
 from slurm_ops_manager.slurm_ops_managers import (
     SlurmDebManager,
     SlurmRpmManager,
@@ -46,6 +47,7 @@ class SlurmManager(Object):
         self.infiniband = Infiniband(charm, component)
         if self._slurm_component == "slurmd":
             self.nvidia = NvidiaGPU(charm, component)
+            self.singularity = Singularity(charm, component)
 
     @property
     def hostname(self):


### PR DESCRIPTION
**Please provide description of the purpose of this pull request, as well as its
motivation and context.**

Create a Singularity class responsible for installing singularity on
slurmd, using .deb (on Ubuntu) and .rpm (on Centos) packages retrieved
from GitHub Releases.

The .deb and .rpm files are slurmd charm resources.

The Singularity install method receives the path to the file from
slurm-charms/charm-slurmd/src/charm.py.

**How was the code tested?**

It works with a slurm-charms up to date version which supports singularity-install action.

Final checklist
- [x] I am the author of these changes, or I have the rights to submit them.
- [ ] I added the relevant changed to the README and/or documentation.
- [x] I self reviewed my own code.
- [ ] I updated the `CHANGELOG` according to the [contributing
  guide](https://omnivector-solutions.github.io/osd-documentation/master/contributing.html#changelog)