### PR TITLE
85 correct default for plugstack conf

### DIFF
--- a/slurm_ops_manager/slurm_deb_manager.py
+++ b/slurm_ops_manager/slurm_deb_manager.py
@@ -141,7 +141,9 @@ class SlurmDebManager(SlurmOpsManagerBase):
         if not self._install_slurm_from_deb():
             return False
 
-        self.setup_plugstack_dir_and_config()
+        if self._slurm_component == "slurmctld":
+             self._setup_plugstack_dir_and_config()
+
         self._setup_paths()
         self.slurm_systemctl('enable')
 

--- a/slurm_ops_manager/slurm_deb_manager.py
+++ b/slurm_ops_manager/slurm_deb_manager.py
@@ -142,7 +142,7 @@ class SlurmDebManager(SlurmOpsManagerBase):
             return False
 
         if self._slurm_component == "slurmctld":
-             self._setup_plugstack_dir_and_config()
+            self._setup_plugstack_dir_and_config()
 
         self._setup_paths()
         self.slurm_systemctl('enable')

--- a/slurm_ops_manager/slurm_deb_manager.py
+++ b/slurm_ops_manager/slurm_deb_manager.py
@@ -141,6 +141,7 @@ class SlurmDebManager(SlurmOpsManagerBase):
         if not self._install_slurm_from_deb():
             return False
 
+        self.setup_plugstack_dir_and_config()
         self._setup_paths()
         self.slurm_systemctl('enable')
 

--- a/slurm_ops_manager/slurm_ops_base.py
+++ b/slurm_ops_manager/slurm_ops_base.py
@@ -712,8 +712,7 @@ class SlurmOpsManagerBase:
         return RSA.generate(2048).export_key('PEM').decode()
 
     def _setup_plugstack_dir_and_config(self) -> None:
-        """Create plugstack directory and config.
-        """
+        """Create plugstack directory and config."""
 
         # Create the plugstack config directory.
         plugstack_dir = self._slurm_plugstack_dir

--- a/slurm_ops_manager/slurm_ops_base.py
+++ b/slurm_ops_manager/slurm_ops_base.py
@@ -711,7 +711,7 @@ class SlurmOpsManagerBase:
         """Generate the rsa key to encode the jwt with."""
         return RSA.generate(2048).export_key('PEM').decode()
 
-    def setup_plugstack_dir_and_config(self) -> None:
+    def _setup_plugstack_dir_and_config(self) -> None:
         """Create plugstack directory and config.
         """
 
@@ -722,7 +722,7 @@ class SlurmOpsManagerBase:
             plugstack_dir.unlink()
 
         plugstack_dir.mkdir()
-        subprocess.call(["chown", "-R", self._slurm_user, plugstack_dir])
+        subprocess.call(["chown", "-R", f"{self._slurm_user}:{self._slurm_group}", plugstack_dir])
 
         # Write the plugstack config.
         plugstack_conf = self._slurm_plugstack_conf

--- a/slurm_ops_manager/slurm_ops_base.py
+++ b/slurm_ops_manager/slurm_ops_base.py
@@ -218,12 +218,12 @@ class SlurmOpsManagerBase:
     @property
     def _slurm_plugstack_dir(self) -> Path:
         """Return the directory to the SPANK plugins."""
-        return Path("/etc/slurm/plugstack.d")
+        return Path("/etc/slurm/plugstack.conf.d")
 
     @property
     def _slurm_plugstack_conf(self) -> Path:
-        """Return the full path to the SPANK configuration file."""
-        return self._slurm_plugstack_dir / 'plugstack.conf' # TODO check this on CentOS
+        """Return the full path to the root plugstack configuration file."""
+        return self._slurm_conf_dir / 'plugstack.conf'
 
     @property
     def _slurm_systemd_service(self) -> str:
@@ -710,3 +710,24 @@ class SlurmOpsManagerBase:
     def generate_jwt_rsa(self) -> str:
         """Generate the rsa key to encode the jwt with."""
         return RSA.generate(2048).export_key('PEM').decode()
+
+    def setup_plugstack_dir_and_config(self) -> None:
+        """Create plugstack directory and config.
+        """
+
+        # Create the plugstack config directory.
+        plugstack_dir = self._slurm_plugstack_dir
+
+        if plugstack_dir.exists():
+            plugstack_dir.unlink()
+
+        plugstack_dir.mkdir()
+        subprocess.call(["chown", "-R", self._slurm_user, plugstack_dir])
+
+        # Write the plugstack config.
+        plugstack_conf = self._slurm_plugstack_conf
+
+        if plugstack_conf.exists():
+            plugstack_conf.unlink()
+
+        plugstack_conf.write_text(f"include {plugstack_dir}/*.conf")

--- a/slurm_ops_manager/slurm_rpm_manager.py
+++ b/slurm_ops_manager/slurm_rpm_manager.py
@@ -117,9 +117,11 @@ class SlurmRpmManager(SlurmOpsManagerBase):
         else:
             user = f"{self._slurm_user}:{self._slurm_group}"
 
-        all_paths = [self._slurm_conf_dir,
-                     self._slurm_state_dir,
-                     self._slurm_spool_dir]
+        all_paths = [
+             self._slurm_conf_dir,
+             self._slurm_state_dir,
+             self._slurm_spool_dir,
+        ] 
 
         for syspath in all_paths:
             if not syspath.exists():
@@ -177,6 +179,7 @@ class SlurmRpmManager(SlurmOpsManagerBase):
             return False
 
         successful_installation = self._install_slurm_from_rpm()
+        self.setup_plugstack_dir_and_config()
         self._setup_paths()
         self.slurm_systemctl('enable')
 

--- a/slurm_ops_manager/slurm_rpm_manager.py
+++ b/slurm_ops_manager/slurm_rpm_manager.py
@@ -179,7 +179,10 @@ class SlurmRpmManager(SlurmOpsManagerBase):
             return False
 
         successful_installation = self._install_slurm_from_rpm()
-        self.setup_plugstack_dir_and_config()
+
+        if self._slurm_component == "slurmctld":
+             self._setup_plugstack_dir_and_config()
+
         self._setup_paths()
         self.slurm_systemctl('enable')
 

--- a/slurm_ops_manager/slurm_rpm_manager.py
+++ b/slurm_ops_manager/slurm_rpm_manager.py
@@ -118,11 +118,10 @@ class SlurmRpmManager(SlurmOpsManagerBase):
             user = f"{self._slurm_user}:{self._slurm_group}"
 
         all_paths = [
-             self._slurm_conf_dir,
-             self._slurm_state_dir,
-             self._slurm_spool_dir,
-        ] 
-
+            self._slurm_conf_dir,
+            self._slurm_state_dir,
+            self._slurm_spool_dir,
+        ]
         for syspath in all_paths:
             if not syspath.exists():
                 syspath.mkdir()
@@ -181,7 +180,7 @@ class SlurmRpmManager(SlurmOpsManagerBase):
         successful_installation = self._install_slurm_from_rpm()
 
         if self._slurm_component == "slurmctld":
-             self._setup_plugstack_dir_and_config()
+            self._setup_plugstack_dir_and_config()
 
         self._setup_paths()
         self.slurm_systemctl('enable')


### PR DESCRIPTION
* Fixes https://github.com/omnivector-solutions/slurm-ops-manager/issues/85 by making sure slurm is configured to use a consistent
plugstack configuration file and confi file location across
centos and ubuntu.

* Adds a function to create the plugstack directory and config.