### PR TITLE
Release 0.8.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 
-__version__ = "0.8.7"
+__version__ = "0.8.8"
 
 setup(
     name='slurm-ops-manager',


### PR DESCRIPTION
**What**

Update the package version to 0.8.8

**Why**

PR (https://github.com/omnivector-solutions/slurm-ops-manager/pull/86) implemented a patch to correct default for plugstack conf

