### PR TITLE
Fix plugstack_dir removal

### DIFF
--- a/slurm_ops_manager/slurm_ops_base.py
+++ b/slurm_ops_manager/slurm_ops_base.py
@@ -718,7 +718,7 @@ class SlurmOpsManagerBase:
         plugstack_dir = self._slurm_plugstack_dir
 
         if plugstack_dir.exists():
-            plugstack_dir.unlink()
+            rmtree(plugstack_dir)
 
         plugstack_dir.mkdir()
         subprocess.call(["chown", "-R", f"{self._slurm_user}:{self._slurm_group}", plugstack_dir])


### PR DESCRIPTION
**What**

Change the way to remove plugstack_dir

**Why**

`Path.unlink()` can not remove a directory. Thus, it needs to be replaced by another function that can.