### PR TITLE
Release 0.8.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 
-__version__ = "0.8.10"
+__version__ = "0.8.11"
 
 setup(
     name='slurm-ops-manager',


### PR DESCRIPTION
**What** 

Bump version to 0.8.11

**Why**

InfiniBand installation support has been removed.