### PR TITLE
Release 0.8.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 
-__version__ = "0.8.11"
+__version__ = "0.8.12"
 
 setup(
     name='slurm-ops-manager',


### PR DESCRIPTION
What

Bump version to 0.8.12

Why

Add support for slurm 22.05.8 and above.