### PR TITLE
ASP-2712: Change default RPM repo

### DIFF
--- a/slurm_ops_manager/slurm_rpm_manager.py
+++ b/slurm_ops_manager/slurm_rpm_manager.py
@@ -143,7 +143,7 @@ class SlurmRpmManager(SlurmOpsManagerBase):
                        "baseurl": custom_repo}
         else:
             context = {"title": "omni-stable",
-                       "baseurl": "https://omnivector-solutions.github.io/repo/centos7/stable/$basearch"} # noqa
+                       "baseurl": "https://omnivector-solutions.github.io/slurm-repo/23.02.1/centos7/$basearch"} # noqa
         logger.debug(f"## Configuring repository for Slurm rpms: {context}")
 
         template_dir = Path(__file__).parent / "templates/"


### PR DESCRIPTION
**What**

Set the default RPM slurm repo to point to Slurm 23.02.1.

**Why**

Slurm will be installed and tested in QA and Staging in upcoming deployments.