### PR TITLE
Release 0.8.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 
-__version__ = "0.8.12"
+__version__ = "0.8.13"
 
 setup(
     name='slurm-ops-manager',


### PR DESCRIPTION
**What**

Bump version to 0.8.13

**Why**

Install Slurm 23.02.1 by default on CentOS7.