### PR TITLE
Allow for unix socket connections

### DIFF
--- a/slurm_ops_manager/templates/slurmdbd.conf.tmpl
+++ b/slurm_ops_manager/templates/slurmdbd.conf.tmpl
@@ -24,8 +24,10 @@ PidFile={{ slurmdbd_pid_file }}
 LogFile={{ slurmdbd_log_file }}
 
 StorageType=accounting_storage/mysql
+{% if db_hostname -%}
 StorageHost={{ db_hostname }}
 StoragePort={{ db_port }}
+{% endif -%}
 StoragePass={{ db_password }}
 StorageUser={{ db_username }}
 StorageLoc={{ db_name }}


### PR DESCRIPTION
In a deployment with a highly available MySQL databsae, the slurmdbd service will use a socket connection to connect to the mysql-router. This requires that the StorageHost and StoragePort are not set in the slurmdbd.conf file as the MySQL connection uses the MYSQL_UNIX_PORT environment variable in order to use a unix socket.